### PR TITLE
fix #7

### DIFF
--- a/src/scss/components/_components.page-navigation.scss
+++ b/src/scss/components/_components.page-navigation.scss
@@ -3,7 +3,7 @@
   flex-direction: column;
   background-color: $color-page-head-background;
   padding: $global-spacing-unit;
-  overflow: scroll;
+  overflow: auto;
 
   &__list {
     list-style: none;


### PR DESCRIPTION
Prevents issue with windows devices and Mac-with-windows-mice devices displaying an ugly scrollbar, It will however still display this when the contents of the navbar no longer fit