### PR TITLE
add empty alt prop

### DIFF
--- a/src/_components/badge.ejs
+++ b/src/_components/badge.ejs
@@ -1,5 +1,5 @@
 <div class="c-badge c-badge--<%= type %> c-badge--<%= name %> <%= typeof size !== 'undefined' ? "c-badge--" + size : ""%>">
-    <img class="c-badge__logo" src="<%= site.baseURL %>/img/badges-<%= type %>/<%= name %>.svg" />
+    <img alt="" class="c-badge__logo" src="<%= site.baseURL %>/img/badges-<%= type %>/<%= name %>.svg" />
     <span class="c-badge__name <%= type === "project" || type === "social" ? "u-hidden-visually" : ""%>">
         <%= name.replace(/-/g, " ") %>
     </span>


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Learn/Accessibility/HTML#Empty_alt_attributes
the alt prop could also be dynamically set if the role of the image is not considered purely decorative. 