### PR TITLE
Rename homepage title, fixes #14

### DIFF
--- a/src/pages/index.ejs
+++ b/src/pages/index.ejs
@@ -1,5 +1,5 @@
 ---
-title: Welcome to Frontmen
+title: Frontmen
 keywords:
 - frontmen
 - front-men


### PR DESCRIPTION
Rename 'welcome to Frontmen' to 'Frontmen'