### PR TITLE
fix on nav opening and closing

### DIFF
--- a/src/js/navigation.js
+++ b/src/js/navigation.js
@@ -2,6 +2,8 @@ const layout = document.querySelector('.o-layout');
 const toggleButton = document.querySelector('.js-menu-toggle');
 const toggleButtonIcon = toggleButton.querySelector('.c-icon');
 const navigationClass = '.o-layout__navigation';
+const item = document.querySelector('.c-page-navigation__list ');
+const link = document.querySelector('.c-page-navigation__link');
 
 const toggleMenu = () => {
   layout.classList.toggle('o-layout--open');
@@ -9,8 +11,24 @@ const toggleMenu = () => {
   toggleButtonIcon.classList.toggle('c-icon--menu-close');
 };
 
+const closeMenu = () => {
+  layout.classList.remove('o-layout--open');
+};
+
 const closeOnClickOutside = selector => {
   const outsideClickListener = event => {
+    if (event.target.closest(selector) === item || link) {
+      event.preventDefault();
+
+      if (event.target.innerHTML === 'Work') {
+        return '/';
+      }
+      closeMenu();
+
+      setTimeout(() => {
+        window.location.href = event.target.href;
+      }, 300);
+    }
     if (event.target.closest(selector) === null) {
       toggleMenu();
       document.removeEventListener('click', outsideClickListener);


### PR DESCRIPTION
This PR fixes the transition animation when closing the navbar from inside the navbar and when clicking a link.

![fix-fm-nav](https://user-images.githubusercontent.com/6505610/49751570-000a8a80-fcae-11e8-93cc-d1ec6f5e7f2d.gif)
